### PR TITLE
Fix to the hash retrieval to account for a FF bug

### DIFF
--- a/jquery.uriAnchor.js
+++ b/jquery.uriAnchor.js
@@ -57,7 +57,7 @@
 
     // Begin internal utility to clean bookmark
     getCleanAnchorString = function () {
-      return String( document.location.hash )
+      return String( document.location.href.split('#')[1] || '' )
         // remove any leading pounds or bangs
         .replace( configMap.regex_anchor_clean1 , '' )
         // snip off after question-mark ( a ClickStreet bug )


### PR DESCRIPTION
FF decodes the hash on read while other browsers do not (http://stackoverflow.com/questions/1703552/encoding-of-window-location-hash)
